### PR TITLE
Fix location of a checkbox

### DIFF
--- a/addon/globalPlugins/speechLogger/configUI.py
+++ b/addon/globalPlugins/speechLogger/configUI.py
@@ -224,7 +224,7 @@ class SpeechLoggerSettings(gui.settingsDialogs.SettingsPanel):
 
 		# Translators: This is the label for a checkbox to turn Say All logging on or off.
 		logSayAllCBLabel = _("Log speech during Say-&All (read to end)")
-		self.logSayAllCB = miscGroupHelper.addItem(wx.CheckBox(self, label=logSayAllCBLabel))
+		self.logSayAllCB = miscGroupHelper.addItem(wx.CheckBox(miscGroupBox, label=logSayAllCBLabel))
 		self.logSayAllCB.SetValue(getConf("logSayAll"))
 
 	def onSave(self):


### PR DESCRIPTION
### Issue

The checkbox "Log speech during Say-All (read to end)" is located at the top of the panel and overlaps the first controls of the panel.

### Solution
The checkbox should have as parent the groupbox of the group to which it belongs to be correctly positionned.

